### PR TITLE
Removed inexistent dependency

### DIFF
--- a/assets/scss/now-ui-dashboard/_nucleo-outline.scss
+++ b/assets/scss/now-ui-dashboard/_nucleo-outline.scss
@@ -12,8 +12,7 @@ Created using IcoMoon - icomoon.io
   src: url('../fonts/nucleo-outline.eot') format('embedded-opentype'),
   url('../fonts/nucleo-outline.woff2') format('woff2'),
   url('../fonts/nucleo-outline.woff') format('woff'),
-  url('../fonts/nucleo-outline.ttf') format('truetype'),
-  url('../fonts/nucleo-outline.svg') format('svg');
+  url('../fonts/nucleo-outline.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Removed nucleo-outline.svg (file _nucleo-outline.scss) dependency which does not exist and causes a problem in the compilation process.